### PR TITLE
[Fixed] package_reviewer failures

### DIFF
--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -1,3 +1,3 @@
 [
-    { "keys": ["alt+r"], "command": "regexexplaintip" }
+    { "keys": ["shift+super+r"], "command": "regexexplaintip" }
 ]

--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -1,3 +1,3 @@
 [
-    { "keys": ["shift+super+r"], "command": "regexexplaintip" }
+    { "keys": ["shift+super+alt+r"], "command": "regexexplaintip" }
 ]

--- a/messages.json
+++ b/messages.json
@@ -1,3 +1,3 @@
 {
-    "v0.9.2": "messages/0.9.2.txt"
+    "0.9.2": "messages/0.9.2.txt"
 }


### PR DESCRIPTION
See test your packages of [**package_reviewer**](https://github.com/packagecontrol/package_reviewer) utility:

### 1. Before pull request

```shell
D:\package_reviewer>python -m package_reviewer "D:\Sublime Text 3 x64\Data\Packages\RegexExplainTiPackage path: D:\Sublime Text 3 x64\Data\Packages\RegexExplainTip

## Report for RegexExplainTip
##########################

Reporting 2 failures:
- Key 'v0.9.2' is not 'install' or a valid semantic version
    File: messages.json
- The binding ['alt+r'] unconditionally overrides a default binding
    File: Default.sublime-keymap

No warnings

For more details on the report messages (for example how to resolve them), go to:
https://github.com/packagecontrol/package_reviewer/wiki
```

I need default <kbd>Alt+R</kbd> shortcut for `toggle_regex` command.

### 2. After pull request

```shell
D:\package_reviewer>python -m package_reviewer "D:\Sublime Text 3 x64\Data\Packages\RegexExplainTiPackage path: D:\Sublime Text 3 x64\Data\Packages\RegexExplainTip

## Report for RegexExplainTip 
##########################

No failures

No warnings

For more details on the report messages (for example how to resolve them), go to:
https://github.com/packagecontrol/package_reviewer/wiki
```

Thanks.